### PR TITLE
skip head and foot js when empty, backport 35230

### DIFF
--- a/lib/outputlib.php
+++ b/lib/outputlib.php
@@ -851,8 +851,11 @@ class theme_config {
     /**
      * Generate a URL to the file that serves theme JavaScript files.
      *
+     * If we determine that the theme has no relevant files, then we return
+     * early with a null value.
+     *
      * @param bool $inhead true means head url, false means footer
-     * @return moodle_url
+     * @return moodle_url|null
      */
     public function javascript_url($inhead) {
         global $CFG;
@@ -860,6 +863,11 @@ class theme_config {
         $rev = theme_get_revision();
         $params = array('theme'=>$this->name,'rev'=>$rev);
         $params['type'] = $inhead ? 'head' : 'footer';
+
+        // Return early if there are no files to serve
+        if (count($this->javascript_files($params['type'])) === 0) {
+            return null;
+        }
 
         if (!empty($CFG->slasharguments) and $rev > 0) {
             $url = new moodle_url("$CFG->httpswwwroot/theme/javascript.php");

--- a/lib/outputrenderers.php
+++ b/lib/outputrenderers.php
@@ -393,10 +393,12 @@ class core_renderer extends renderer_base {
         }
 
         // Get the theme javascript head and footer
-        $jsurl = $this->page->theme->javascript_url(true);
-        $this->page->requires->js($jsurl, true);
-        $jsurl = $this->page->theme->javascript_url(false);
-        $this->page->requires->js($jsurl);
+        if ($jsurl = $this->page->theme->javascript_url(true)) {
+            $this->page->requires->js($jsurl, true);
+        }
+        if ($jsurl = $this->page->theme->javascript_url(false)) {
+            $this->page->requires->js($jsurl);
+        }
 
         // Get any HTML from the page_requirements_manager.
         $output .= $this->page->requires->get_head_code($this->page, $this);


### PR DESCRIPTION
closes universityofglasgow/issues#28
